### PR TITLE
Lógica de detección de crisis hipotensiva

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,7 @@
+import dotenv from "dotenv";
+dotenv.config({path: ".env.local"});
+
+export const psys_low = process.env.PSYS_LOW;
+export const pdys_low = process.env.PDYS_LOW;
+
+

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:ci": "jest --ci"
   },
   "dependencies": {
+    "dotenv": "^17.2.2",
     "next": "14.2.5",
     "next-auth": "^4.24.11",
     "next-pwa": "5.6.0",

--- a/test/bloodPressure.test.js
+++ b/test/bloodPressure.test.js
@@ -1,0 +1,45 @@
+import { isHypotensiveCrisis } from "../utils/bloodPressure.js";
+
+describe("isHypotensiveCrisis", () => {
+  test("should return true for systolic <= threshold (e.g. 90)", () => {
+    expect(isHypotensiveCrisis(90, 80)).toBe(true);
+    expect(isHypotensiveCrisis(85, 75)).toBe(true);
+    expect(isHypotensiveCrisis(70, 90)).toBe(true);
+  });
+
+  test("should return true for diastolic <= threshold (e.g. 60)", () => {
+    expect(isHypotensiveCrisis(100, 60)).toBe(true);
+    expect(isHypotensiveCrisis(110, 55)).toBe(true);
+    expect(isHypotensiveCrisis(95, 50)).toBe(true);
+  });
+
+  test("should return true when both systolic and diastolic are low", () => {
+    expect(isHypotensiveCrisis(85, 55)).toBe(true);
+    expect(isHypotensiveCrisis(70, 40)).toBe(true);
+  });
+
+  test("should return false for normal blood pressure", () => {
+    expect(isHypotensiveCrisis(120, 80)).toBe(false);
+    expect(isHypotensiveCrisis(110, 70)).toBe(false);
+    expect(isHypotensiveCrisis(130, 85)).toBe(false);
+  });
+
+  test("should return false for high pressure levels", () => {
+    expect(isHypotensiveCrisis(140, 90)).toBe(false);
+    expect(isHypotensiveCrisis(150, 100)).toBe(false);
+    expect(isHypotensiveCrisis(180, 110)).toBe(false);
+  });
+
+  test("should handle edge cases at threshold exactly", () => {
+    expect(isHypotensiveCrisis(90, 70)).toBe(true); // sys == 90
+    expect(isHypotensiveCrisis(100, 60)).toBe(true); // dias == 60
+    expect(isHypotensiveCrisis(90, 60)).toBe(true); // both on threshold
+  });
+
+  test("should handle invalid inputs gracefully", () => {
+    expect(isHypotensiveCrisis(null, 80)).toBe(false);
+    expect(isHypotensiveCrisis(120, null)).toBe(false);
+    expect(isHypotensiveCrisis(undefined, undefined)).toBe(false);
+    expect(isHypotensiveCrisis("abc", "def")).toBe(false);
+  });
+});

--- a/utils/bloodPressure.js
+++ b/utils/bloodPressure.js
@@ -1,0 +1,14 @@
+import { psys_low, pdys_low } from "../config/config";
+
+export function isHypotensiveCrisis(systolic, diastolic) {
+  const sysLow = parseInt(psys_low) || 90;
+  const diasLow = parseInt(pdys_low) || 60;
+
+  // Validación segura
+  const validSystolic = typeof systolic === "number" && !isNaN(systolic);
+  const validDiastolic = typeof diastolic === "number" && !isNaN(diastolic);
+
+  if (!validSystolic || !validDiastolic) return false;
+
+  return systolic <= sysLow || diastolic <= diasLow;
+}


### PR DESCRIPTION
Se implementa lógica de detección de crisis hipotensiva mediante la función isHypotensiveCrisis y su correspondiente batería de test. Se instala modulo dotenv para importar las variables de .env.local PSYS_LOW y PDYS_LOW referentes a la HU3.